### PR TITLE
Fixes issues IOS-1385, IOS-1389, IOS-1386

### DIFF
--- a/ActivitiSDK/FormRenderEngine/Cells/CollectionViewCells/ASDKRadioFieldCollectionViewCell.m
+++ b/ActivitiSDK/FormRenderEngine/Cells/CollectionViewCells/ASDKRadioFieldCollectionViewCell.m
@@ -92,7 +92,25 @@
                 optionNameForRestFormField = formVariable.value;
             }
             
-            descriptionLabelText = [NSString stringWithFormat:@"%@ (%@)", restFormField.values.firstObject, optionNameForRestFormField];
+            if (ASDKModelFormFieldRepresentationTypeReadOnly == restFormField.representationType) {
+                NSString *stringValue = restFormField.values.firstObject;
+                
+                if (stringValue.length) {
+                    descriptionLabelText = stringValue;
+                }
+                
+                if (optionNameForRestFormField.length) {
+                    if (descriptionLabelText.length) {
+                        descriptionLabelText = [NSString stringWithFormat:@"%@ (%@)", descriptionLabelText, optionNameForRestFormField];
+                    }
+                }
+                
+                if (!descriptionLabelText.length) {
+                    descriptionLabelText = kASDKFormFieldEmptyStringValue;
+                }
+            } else {
+                descriptionLabelText = optionNameForRestFormField;
+            }
         }
     } else if (restFormField.representationType == ASDKModelFormFieldRepresentationTypeDropdown &&
                restFormField.restURL) {

--- a/ActivitiSDK/FormRenderEngine/Controllers/FormFieldDetailControllers/ASDKTypeaheadFormFieldDetailsViewController.m
+++ b/ActivitiSDK/FormRenderEngine/Controllers/FormFieldDetailControllers/ASDKTypeaheadFormFieldDetailsViewController.m
@@ -157,29 +157,7 @@
     UITableViewCell *typeaheadCell = nil;
     
     if (indexPath.row == 0) {
-        NSString *optionValue = nil;
-        
-        if (self.currentFormField.values.count) {
-            NSString *labelValue = nil;
-            
-            NSString *formFieldValue = self.currentFormField.values.firstObject;
-            NSPredicate *metadataPredicate = [NSPredicate predicateWithFormat:@"modelID == %@", formFieldValue];
-            ASDKModelFormFieldOption *formFieldOption = [self.currentFormField.formFieldOptions filteredArrayUsingPredicate:metadataPredicate].firstObject;
-            labelValue = formFieldOption.name;
-            
-            if (!labelValue) {
-                ASDKModelFormVariable *formVariable = self.currentFormField.formFieldParams.values.firstObject;
-                labelValue = formVariable.value;
-            }
-            
-            if (labelValue) {
-                optionValue = [NSString stringWithFormat:@"%@ (%@)",formFieldValue, labelValue];
-            } else {
-                optionValue = [NSString stringWithFormat:@"%@", formFieldValue];
-            }
-        } else {
-            optionValue = self.currentFormField.metadataValue.option.attachedValue;
-        }
+        NSString *optionValue = [self optionValueForTypeaheadCell];
         
         ASDKTypeaheadValueTableViewCell *typeaheadValueCell =
         [tableView dequeueReusableCellWithIdentifier:kASDKCellIDFormFieldTypeaheadRepresentation
@@ -285,6 +263,46 @@
                             range:range];
     
     return attributedText;
+}
+
+- (NSString *)optionValueForTypeaheadCell {
+    NSString *optionValue = nil;
+    
+    if (self.currentFormField.values.count) {
+        NSString *labelValue = nil;
+        
+        NSString *formFieldValue = self.currentFormField.values.firstObject;
+        NSPredicate *metadataPredicate = [NSPredicate predicateWithFormat:@"modelID == %@", formFieldValue];
+        ASDKModelFormFieldOption *formFieldOption = [self.currentFormField.formFieldOptions filteredArrayUsingPredicate:metadataPredicate].firstObject;
+        labelValue = formFieldOption.name;
+        
+        if (!labelValue) {
+            ASDKModelFormVariable *formVariable = self.currentFormField.formFieldParams.values.firstObject;
+            labelValue = formVariable.value;
+        }
+        
+        if (ASDKModelFormFieldRepresentationTypeReadOnly == self.currentFormField.representationType) {
+            if (formFieldValue.length) {
+                optionValue = formFieldValue;
+            }
+            
+            if (labelValue.length) {
+                if (optionValue.length) {
+                    optionValue = [NSString stringWithFormat:@"%@ (%@)", optionValue, labelValue];
+                }
+            }
+            
+            if (!optionValue.length) {
+                optionValue = kASDKFormFieldEmptyStringValue;
+            }
+        } else {
+            optionValue = labelValue;
+        }
+    } else {
+        optionValue = self.currentFormField.metadataValue.option.attachedValue;
+    }
+    
+    return optionValue;
 }
 
 

--- a/ActivitiSDK/NetworkServices/RequestRepresentations/FormInformation/ASDKFormFieldValueRequestRepresentation.m
+++ b/ActivitiSDK/NetworkServices/RequestRepresentations/FormInformation/ASDKFormFieldValueRequestRepresentation.m
@@ -127,7 +127,8 @@
             }
             // special radio / dropdown field handling
             else if (formField.representationType == ASDKModelFormFieldRepresentationTypeDropdown ||
-                     formField.representationType == ASDKModelFormFieldRepresentationTypeRadio) {
+                     formField.representationType == ASDKModelFormFieldRepresentationTypeRadio ||
+                     formField.representationType == ASDKModelFormFieldRepresentationTypeTypeahead) {
                 formFieldValue = [self handleDropdownAndRadioFormFieldValueRepresentationForFormField:formField];
             }
             // special people field handling


### PR DESCRIPTION
IOS-1385 - After saving and reviewing the form the IDs in Typeahead fields are displayed
IOS-1389 - Null is displayed on a Display value of a typeahead field
IOS-1386 - The typeahead fields are cleared after re-saving the form